### PR TITLE
Standardize normalization in Connect op

### DIFF
--- a/examples/classification.py
+++ b/examples/classification.py
@@ -4,9 +4,9 @@ from torch_geometric import seed_everything
 from torch_geometric.datasets import TUDataset
 from torch_geometric.loader import DataLoader
 from torch_geometric.nn import DenseGCNConv, GCNConv
-from torch_sparse import SparseTensor
 
 from tgp.poolers import get_pooler, pooler_map
+from tgp.utils import connectivity_to_sparse_tensor
 
 seed_everything(8)  # Reproducibility
 
@@ -80,8 +80,9 @@ for POOLER, value in pooler_map.items():  # Use all poolers
                 self.lin = torch.nn.Linear(hidden_channels, num_classes)
 
             def forward(self, x, edge_index, edge_weight, batch=None):
-                edge_index = SparseTensor.from_edge_index(
-                    edge_index, edge_attr=edge_weight
+                num_nodes = x.size(0)
+                edge_index = connectivity_to_sparse_tensor(
+                    edge_index, edge_weight, num_nodes
                 )
 
                 # First MP layer

--- a/tests/test_asap.py
+++ b/tests/test_asap.py
@@ -74,6 +74,7 @@ def test_forward_with_gnn_and_sparse_adj_and_add_self_loops_and_extra_repr():
         dropout=0.1,
         negative_slope=0.1,
         nonlinearity="sigmoid",
+        remove_self_loops=False,
     )
     pooler.eval()
     pooler.reset_parameters()
@@ -124,6 +125,16 @@ def test_graph_disconnected_case():
 
     out = pooler(x=x, adj=edge_index, so=None, batch=batch, lifting=False)
     assert isinstance(out, PoolingOutput)
+
+
+def test_both_add_and_remove_self_loops_raises_error():
+    """Test that ASAPooling raises ValueError when both add_self_loops and remove_self_loops are True."""
+    with pytest.raises(
+        ValueError, match="remove_self_loops and add_self_loops cannot be both True"
+    ):
+        ASAPooling(
+            in_channels=3, ratio=0.5, add_self_loops=True, remove_self_loops=True
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_edge_weight_normalization.py
+++ b/tests/test_edge_weight_normalization.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Test edge weight normalization across all connect methods.
+Tests: SparseConnect, DenseConnect, DenseConnectSPT
+"""
+
+import pytest
+import torch
+from torch_geometric.data import Batch, Data
+from torch_sparse import SparseTensor
+
+from tgp.connect import DenseConnect, DenseConnectSPT, SparseConnect
+from tgp.reduce import BaseReduce
+from tgp.select import TopkSelect
+
+
+class TestEdgeWeightNormalization:
+    """Test edge weight normalization functionality."""
+
+    def create_batch_graphs(self):
+        """Create batched test graphs - the proper way to test."""
+        # Graph 1: 4 nodes
+        data1 = Data(
+            x=torch.randn(4, 3),
+            edge_index=torch.tensor([[0, 1, 1, 2, 2, 3], [1, 0, 2, 1, 3, 2]]),
+            edge_weight=torch.tensor([1.0, 2.0, 4.0, 3.0, 6.0, 2.0]),  # max = 6.0
+        )
+
+        # Graph 2: 3 nodes
+        data2 = Data(
+            x=torch.randn(3, 3),
+            edge_index=torch.tensor([[0, 1, 2], [1, 2, 0]]),
+            edge_weight=torch.tensor([8.0, 2.0, 4.0]),  # max = 8.0
+        )
+
+        return Batch.from_data_list([data1, data2])
+
+    def create_single_graph_batch(self):
+        """Create a single graph in batch format (batch_size=1)."""
+        data = Data(
+            x=torch.randn(4, 3),
+            edge_index=torch.tensor([[0, 1, 1, 2, 2, 3], [1, 0, 2, 1, 3, 2]]),
+            edge_weight=torch.tensor([2.0, 4.0, 6.0, 8.0, 10.0, 3.0]),  # max = 10.0
+        )
+        return Batch.from_data_list([data])
+
+    def get_select_output_and_batch_pooled(self, batch_data, ratio=0.5):
+        """Get SelectOutput and compute batch_pooled."""
+        selector = TopkSelect(in_channels=batch_data.x.size(1), ratio=ratio)
+        so = selector(batch_data.x, batch=batch_data.batch)
+        batch_pooled = BaseReduce.reduce_batch(so, batch_data.batch)
+        return so, batch_pooled
+
+    def create_dense_adjacency(self, batch_data):
+        """Create dense adjacency matrices for DenseConnect testing."""
+        batch_size = batch_data.batch.max().item() + 1
+        max_nodes = (
+            (batch_data.batch == 0).sum().item()
+        )  # Assume same size for simplicity
+
+        # Create dense adjacency matrices
+        adj_dense = torch.zeros(batch_size, max_nodes, max_nodes)
+
+        for batch_idx in range(batch_size):
+            # Get nodes for this graph
+            node_mask = batch_data.batch == batch_idx
+            graph_nodes = node_mask.sum().item()
+
+            # Get edges for this graph
+            edge_mask = (
+                node_mask[batch_data.edge_index[0]]
+                & node_mask[batch_data.edge_index[1]]
+            )
+            graph_edges = batch_data.edge_index[:, edge_mask]
+            graph_weights = batch_data.edge_weight[edge_mask]
+
+            # Convert to local node indices
+            node_mapping = torch.zeros(batch_data.num_nodes, dtype=torch.long)
+            node_mapping[node_mask] = torch.arange(graph_nodes)
+            local_edges = node_mapping[graph_edges]
+
+            # Fill dense matrix
+            adj_dense[batch_idx, local_edges[0], local_edges[1]] = graph_weights
+
+        return adj_dense
+
+    # ===== SPARSE CONNECT TESTS =====
+
+    def test_sparse_connect_assertion_error(self):
+        """Test that SparseConnect raises AssertionError when batch_pooled is None."""
+        batch_data = self.create_batch_graphs()
+        so, _ = self.get_select_output_and_batch_pooled(batch_data)
+
+        connector = SparseConnect(normalize_edge_weight=True)
+
+        with pytest.raises(AssertionError, match="batch_pooled parameter is required"):
+            connector(
+                batch_data.edge_index,
+                so,
+                edge_weight=batch_data.edge_weight,
+                batch_pooled=None,
+            )
+
+    def test_sparse_connect_with_batch_pooled(self):
+        """Test SparseConnect with proper batch_pooled parameter."""
+        batch_data = self.create_batch_graphs()
+        so, batch_pooled = self.get_select_output_and_batch_pooled(batch_data)
+
+        # Test without normalization
+        connector = SparseConnect(normalize_edge_weight=False)
+        edge_index_orig, edge_weight_orig = connector(
+            batch_data.edge_index, so, edge_weight=batch_data.edge_weight
+        )
+
+        # Test with normalization
+        connector_norm = SparseConnect(normalize_edge_weight=True)
+        edge_index_norm, edge_weight_norm = connector_norm(
+            batch_data.edge_index,
+            so,
+            edge_weight=batch_data.edge_weight,
+            batch_pooled=batch_pooled,
+        )
+
+        # Check that structure is preserved
+        torch.testing.assert_close(edge_index_orig, edge_index_norm)
+
+        # Check normalization: each graph should be normalized by its own max
+        if edge_weight_norm is not None:
+            assert edge_weight_norm.abs().max() <= 1.0 + 1e-6
+
+            # Verify per-graph normalization
+            for graph_id in range(batch_pooled.max().item() + 1):
+                graph_mask = batch_pooled[edge_index_norm[0]] == graph_id
+                if graph_mask.any():
+                    graph_weights_norm = edge_weight_norm[graph_mask]
+                    graph_weights_orig = edge_weight_orig[graph_mask]
+                    expected_norm = graph_weights_orig / graph_weights_orig.abs().max()
+                    torch.testing.assert_close(
+                        graph_weights_norm, expected_norm, atol=1e-6, rtol=1e-6
+                    )
+
+    def test_sparse_connect_single_graph_batch(self):
+        """Test SparseConnect with single graph (batch_size=1)."""
+        batch_data = self.create_single_graph_batch()
+        so, batch_pooled = self.get_select_output_and_batch_pooled(batch_data)
+
+        connector = SparseConnect(normalize_edge_weight=True)
+        edge_index, edge_weight = connector(
+            batch_data.edge_index,
+            so,
+            edge_weight=batch_data.edge_weight,
+            batch_pooled=batch_pooled,
+        )
+
+        if edge_weight is not None:
+            # Should normalize by global max for single graph
+            assert edge_weight.abs().max() <= 1.0 + 1e-6
+
+    def test_sparse_connect_repr(self):
+        """Test SparseConnect __repr__ includes normalize_edge_weight."""
+        connector = SparseConnect(normalize_edge_weight=True)
+        repr_str = repr(connector)
+        assert "normalize_edge_weight=True" in repr_str
+
+    # ===== DENSE CONNECT TESTS =====
+
+    def test_dense_connect_with_batched_adjacency(self):
+        """Test DenseConnect with 3D batched adjacency matrices."""
+        batch_data = self.create_batch_graphs()
+
+        # Create dense adjacency matrices
+        adj_dense = self.create_dense_adjacency(batch_data)
+
+        # Get SelectOutput (need dense assignment matrix)
+        selector = TopkSelect(in_channels=batch_data.x.size(1), ratio=0.5)
+        so = selector(batch_data.x, batch=batch_data.batch)
+
+        # Convert sparse assignment to dense batched format
+        s_dense = so.s.to_dense()
+        batch_size = batch_data.batch.max().item() + 1
+        max_nodes = adj_dense.size(1)
+        max_supernodes = so.num_supernodes
+
+        # Create batched dense assignment matrix
+        s_batched = torch.zeros(batch_size, max_nodes, max_supernodes)
+        start_node = 0
+        start_supernode = 0
+
+        for batch_idx in range(batch_size):
+            graph_nodes = (batch_data.batch == batch_idx).sum().item()
+            graph_supernodes = (
+                (BaseReduce.reduce_batch(so, batch_data.batch) == batch_idx)
+                .sum()
+                .item()
+            )
+
+            s_batched[
+                batch_idx,
+                :graph_nodes,
+                start_supernode : start_supernode + graph_supernodes,
+            ] = s_dense[
+                start_node : start_node + graph_nodes,
+                start_supernode : start_supernode + graph_supernodes,
+            ]
+
+            start_node += graph_nodes
+            start_supernode += graph_supernodes
+
+        # Test without normalization
+        connector = DenseConnect(normalize_edge_weight=False)
+        adj_orig, _ = connector(adj_dense, type("SO", (), {"s": s_batched})())
+
+        # Test with normalization
+        connector_norm = DenseConnect(normalize_edge_weight=True)
+        adj_norm, _ = connector_norm(adj_dense, type("SO", (), {"s": s_batched})())
+
+        # Check that normalization happened per graph
+        assert adj_norm.abs().max() <= 1.0 + 1e-6
+
+        # Each graph (batch dimension) should be normalized independently
+        for batch_idx in range(batch_size):
+            graph_adj_orig = adj_orig[batch_idx]
+            graph_adj_norm = adj_norm[batch_idx]
+            max_val = graph_adj_orig.abs().max()
+            if max_val > 0:
+                expected_norm = graph_adj_orig / max_val
+                torch.testing.assert_close(
+                    graph_adj_norm, expected_norm, atol=1e-6, rtol=1e-6
+                )
+
+    def test_dense_connect_repr(self):
+        """Test DenseConnect __repr__ includes normalize_edge_weight."""
+        connector = DenseConnect(normalize_edge_weight=True)
+        repr_str = repr(connector)
+        assert "normalize_edge_weight=True" in repr_str
+
+    # ===== DENSE CONNECT SPT TESTS =====
+
+    def test_dense_connect_spt_assertion_error(self):
+        """Test that DenseConnectSPT raises AssertionError when batch_pooled is None."""
+        batch_data = self.create_batch_graphs()
+        so, _ = self.get_select_output_and_batch_pooled(batch_data)
+
+        connector = DenseConnectSPT(normalize_edge_weight=True)
+
+        with pytest.raises(AssertionError, match="batch_pooled parameter is required"):
+            connector(
+                batch_data.edge_index, batch_data.edge_weight, so, batch_pooled=None
+            )
+
+    def test_dense_connect_spt_with_batch_pooled(self):
+        """Test DenseConnectSPT with proper batch_pooled parameter."""
+        batch_data = self.create_batch_graphs()
+        so, batch_pooled = self.get_select_output_and_batch_pooled(batch_data)
+
+        # Test without normalization
+        connector = DenseConnectSPT(normalize_edge_weight=False)
+        adj_orig, _ = connector(batch_data.edge_index, batch_data.edge_weight, so)
+
+        # Test with normalization
+        connector_norm = DenseConnectSPT(normalize_edge_weight=True)
+        adj_norm, _ = connector_norm(
+            batch_data.edge_index, batch_data.edge_weight, so, batch_pooled=batch_pooled
+        )
+
+        # Check normalization
+        if isinstance(adj_norm, SparseTensor):
+            _, _, values = adj_norm.coo()
+            if len(values) > 0:
+                assert values.abs().max() <= 1.0 + 1e-6
+
+                # Verify per-graph normalization
+                for graph_id in range(batch_pooled.max().item() + 1):
+                    # Get original values for this graph
+                    _, _, orig_values = adj_orig.coo()
+                    row_orig, _, _ = adj_orig.coo()
+                    graph_mask_orig = batch_pooled[row_orig] == graph_id
+
+                    if graph_mask_orig.any():
+                        graph_values_orig = orig_values[graph_mask_orig]
+                        row_norm, _, _ = adj_norm.coo()
+                        graph_mask_norm = batch_pooled[row_norm] == graph_id
+                        graph_values_norm = values[graph_mask_norm]
+
+                        max_val = graph_values_orig.abs().max()
+                        if max_val > 0:
+                            expected_norm = graph_values_orig / max_val
+                            torch.testing.assert_close(
+                                graph_values_norm, expected_norm, atol=1e-5, rtol=1e-5
+                            )
+
+    def test_dense_connect_spt_repr(self):
+        """Test DenseConnectSPT __repr__ includes normalize_edge_weight."""
+        connector = DenseConnectSPT(normalize_edge_weight=True)
+        repr_str = repr(connector)
+        assert "normalize_edge_weight=True" in repr_str
+
+    # ===== EDGE CASES =====
+
+    def test_zero_edge_weights(self):
+        """Test normalization with zero edge weights (division by zero)."""
+        batch_data = self.create_batch_graphs()
+        batch_data.edge_weight = torch.zeros_like(batch_data.edge_weight)
+        so, batch_pooled = self.get_select_output_and_batch_pooled(batch_data)
+
+        # SparseConnect
+        connector = SparseConnect(normalize_edge_weight=True)
+        edge_index, edge_weight = connector(
+            batch_data.edge_index,
+            so,
+            edge_weight=batch_data.edge_weight,
+            batch_pooled=batch_pooled,
+        )
+
+        if edge_weight is not None:
+            assert not torch.isnan(edge_weight).any()
+            assert not torch.isinf(edge_weight).any()
+            torch.testing.assert_close(edge_weight, torch.zeros_like(edge_weight))
+
+    def test_negative_edge_weights(self):
+        """Test normalization preserves signs with negative edge weights."""
+        batch_data = self.create_batch_graphs()
+        batch_data.edge_weight = torch.tensor(
+            [-2.0, 4.0, -6.0, 1.0, -8.0, 3.0, -10.0, 2.0, 5.0]
+        )
+        so, batch_pooled = self.get_select_output_and_batch_pooled(batch_data)
+
+        connector = SparseConnect(normalize_edge_weight=True)
+        edge_index, edge_weight = connector(
+            batch_data.edge_index,
+            so,
+            edge_weight=batch_data.edge_weight,
+            batch_pooled=batch_pooled,
+        )
+
+        if edge_weight is not None:
+            # Should preserve signs and normalize by absolute maximum
+            assert edge_weight.abs().max() <= 1.0 + 1e-6
+            # Check that signs are preserved (if original had negatives, normalized should too)
+            orig_has_negative = (batch_data.edge_weight < 0).any()
+            norm_has_negative = (edge_weight < 0).any()
+            if orig_has_negative:
+                assert norm_has_negative
+
+    def test_consistency_across_methods(self):
+        """Test that all methods show consistent normalization behavior."""
+        batch_data = (
+            self.create_single_graph_batch()
+        )  # Use single graph for consistency
+        so, batch_pooled = self.get_select_output_and_batch_pooled(batch_data)
+
+        # Test SparseConnect
+        sparse_connector = SparseConnect(normalize_edge_weight=True)
+        _, sparse_weights = sparse_connector(
+            batch_data.edge_index,
+            so,
+            edge_weight=batch_data.edge_weight,
+            batch_pooled=batch_pooled,
+        )
+
+        # Test DenseConnectSPT
+        spt_connector = DenseConnectSPT(normalize_edge_weight=True)
+        spt_adj, _ = spt_connector(
+            batch_data.edge_index, batch_data.edge_weight, so, batch_pooled=batch_pooled
+        )
+
+        # Both should normalize to similar ranges
+        if sparse_weights is not None:
+            assert sparse_weights.abs().max() <= 1.0 + 1e-6
+
+        if isinstance(spt_adj, SparseTensor):
+            _, _, spt_values = spt_adj.coo()
+            if len(spt_values) > 0:
+                assert spt_values.abs().max() <= 1.0 + 1e-6
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_edge_weight_normalization.py
+++ b/tests/test_edge_weight_normalization.py
@@ -90,7 +90,7 @@ class TestEdgeWeightNormalization:
         batch_data = self.create_batch_graphs()
         so, _ = self.get_select_output_and_batch_pooled(batch_data)
 
-        connector = SparseConnect(normalize_edge_weight=True)
+        connector = SparseConnect(edge_weight_norm=True)
 
         with pytest.raises(AssertionError, match="batch_pooled parameter is required"):
             connector(
@@ -106,13 +106,13 @@ class TestEdgeWeightNormalization:
         so, batch_pooled = self.get_select_output_and_batch_pooled(batch_data)
 
         # Test without normalization
-        connector = SparseConnect(normalize_edge_weight=False)
+        connector = SparseConnect(edge_weight_norm=False)
         edge_index_orig, edge_weight_orig = connector(
             batch_data.edge_index, so, edge_weight=batch_data.edge_weight
         )
 
         # Test with normalization
-        connector_norm = SparseConnect(normalize_edge_weight=True)
+        connector_norm = SparseConnect(edge_weight_norm=True)
         edge_index_norm, edge_weight_norm = connector_norm(
             batch_data.edge_index,
             so,
@@ -143,7 +143,7 @@ class TestEdgeWeightNormalization:
         batch_data = self.create_single_graph_batch()
         so, batch_pooled = self.get_select_output_and_batch_pooled(batch_data)
 
-        connector = SparseConnect(normalize_edge_weight=True)
+        connector = SparseConnect(edge_weight_norm=True)
         edge_index, edge_weight = connector(
             batch_data.edge_index,
             so,
@@ -156,10 +156,10 @@ class TestEdgeWeightNormalization:
             assert edge_weight.abs().max() <= 1.0 + 1e-6
 
     def test_sparse_connect_repr(self):
-        """Test SparseConnect __repr__ includes normalize_edge_weight."""
-        connector = SparseConnect(normalize_edge_weight=True)
+        """Test SparseConnect __repr__ includes edge_weight_norm."""
+        connector = SparseConnect(edge_weight_norm=True)
         repr_str = repr(connector)
-        assert "normalize_edge_weight=True" in repr_str
+        assert "edge_weight_norm=True" in repr_str
 
     def test_sparse_connect_degree_norm(self):
         """Test SparseConnect degree_norm feature."""
@@ -197,7 +197,7 @@ class TestEdgeWeightNormalization:
         batch_data = self.create_single_graph_batch()
         so, _ = self.get_select_output_and_batch_pooled(batch_data)
 
-        # degree_norm should work without batch_pooled (unlike normalize_edge_weight)
+        # degree_norm should work without batch_pooled (unlike edge_weight_norm)
         connector = SparseConnect(degree_norm=True)
         edge_index, edge_weight = connector(
             batch_data.edge_index,
@@ -211,12 +211,12 @@ class TestEdgeWeightNormalization:
             assert not torch.isinf(edge_weight).any()
 
     def test_sparse_connect_degree_norm_and_normalize_combined(self):
-        """Test SparseConnect with both degree_norm and normalize_edge_weight."""
+        """Test SparseConnect with both degree_norm and edge_weight_norm."""
         batch_data = self.create_batch_graphs()
         so, batch_pooled = self.get_select_output_and_batch_pooled(batch_data)
 
         # Test with both features enabled
-        connector = SparseConnect(degree_norm=True, normalize_edge_weight=True)
+        connector = SparseConnect(degree_norm=True, edge_weight_norm=True)
         edge_index, edge_weight = connector(
             batch_data.edge_index,
             so,
@@ -226,7 +226,7 @@ class TestEdgeWeightNormalization:
 
         if edge_weight is not None:
             # Both transformations should be applied
-            assert edge_weight.abs().max() <= 1.0 + 1e-6  # normalize_edge_weight
+            assert edge_weight.abs().max() <= 1.0 + 1e-6  # edge_weight_norm
             assert not torch.isnan(edge_weight).any()
             assert not torch.isinf(edge_weight).any()
 
@@ -237,10 +237,10 @@ class TestEdgeWeightNormalization:
         assert "degree_norm=True" in repr_str
 
         # Test with both features
-        connector_both = SparseConnect(degree_norm=True, normalize_edge_weight=True)
+        connector_both = SparseConnect(degree_norm=True, edge_weight_norm=True)
         repr_str_both = repr(connector_both)
         assert "degree_norm=True" in repr_str_both
-        assert "normalize_edge_weight=True" in repr_str_both
+        assert "edge_weight_norm=True" in repr_str_both
 
     # ===== DENSE CONNECT TESTS =====
 
@@ -286,11 +286,11 @@ class TestEdgeWeightNormalization:
         s_batched[1, 3, 1] = 1.0
 
         # Test without normalization
-        connector = DenseConnect(normalize_edge_weight=False)
+        connector = DenseConnect(edge_weight_norm=False)
         adj_orig, _ = connector(adj_dense, type("SO", (), {"s": s_batched})())
 
         # Test with normalization
-        connector_norm = DenseConnect(normalize_edge_weight=True)
+        connector_norm = DenseConnect(edge_weight_norm=True)
         adj_norm, _ = connector_norm(adj_dense, type("SO", (), {"s": s_batched})())
 
         # Check that normalization happened per graph
@@ -310,10 +310,10 @@ class TestEdgeWeightNormalization:
                 )
 
     def test_dense_connect_repr(self):
-        """Test DenseConnect __repr__ includes normalize_edge_weight."""
-        connector = DenseConnect(normalize_edge_weight=True)
+        """Test DenseConnect __repr__ includes edge_weight_norm."""
+        connector = DenseConnect(edge_weight_norm=True)
         repr_str = repr(connector)
-        assert "normalize_edge_weight=True" in repr_str
+        assert "edge_weight_norm=True" in repr_str
 
     # ===== DENSE CONNECT SPT TESTS =====
 
@@ -322,7 +322,7 @@ class TestEdgeWeightNormalization:
         batch_data = self.create_batch_graphs()
         so, _ = self.get_select_output_and_batch_pooled(batch_data)
 
-        connector = DenseConnectSPT(normalize_edge_weight=True)
+        connector = DenseConnectSPT(edge_weight_norm=True)
 
         with pytest.raises(AssertionError, match="batch_pooled parameter is required"):
             connector(
@@ -335,11 +335,11 @@ class TestEdgeWeightNormalization:
         so, batch_pooled = self.get_select_output_and_batch_pooled(batch_data)
 
         # Test without normalization
-        connector = DenseConnectSPT(normalize_edge_weight=False)
+        connector = DenseConnectSPT(edge_weight_norm=False)
         adj_orig, _ = connector(batch_data.edge_index, batch_data.edge_weight, so)
 
         # Test with normalization
-        connector_norm = DenseConnectSPT(normalize_edge_weight=True)
+        connector_norm = DenseConnectSPT(edge_weight_norm=True)
         adj_norm, _ = connector_norm(
             batch_data.edge_index, batch_data.edge_weight, so, batch_pooled=batch_pooled
         )
@@ -371,10 +371,10 @@ class TestEdgeWeightNormalization:
                             )
 
     def test_dense_connect_spt_repr(self):
-        """Test DenseConnectSPT __repr__ includes normalize_edge_weight."""
-        connector = DenseConnectSPT(normalize_edge_weight=True)
+        """Test DenseConnectSPT __repr__ includes edge_weight_norm."""
+        connector = DenseConnectSPT(edge_weight_norm=True)
         repr_str = repr(connector)
-        assert "normalize_edge_weight=True" in repr_str
+        assert "edge_weight_norm=True" in repr_str
 
     # ===== EDGE CASES =====
 
@@ -385,7 +385,7 @@ class TestEdgeWeightNormalization:
         so, batch_pooled = self.get_select_output_and_batch_pooled(batch_data)
 
         # SparseConnect
-        connector = SparseConnect(normalize_edge_weight=True)
+        connector = SparseConnect(edge_weight_norm=True)
         edge_index, edge_weight = connector(
             batch_data.edge_index,
             so,

--- a/tests/test_edge_weight_normalization.py
+++ b/tests/test_edge_weight_normalization.py
@@ -317,31 +317,6 @@ class TestEdgeWeightNormalization:
             assert not torch.isinf(edge_weight).any()
             torch.testing.assert_close(edge_weight, torch.zeros_like(edge_weight))
 
-    def test_negative_edge_weights(self):
-        """Test normalization preserves signs with negative edge weights."""
-        batch_data = self.create_batch_graphs()
-        batch_data.edge_weight = torch.tensor(
-            [-2.0, 4.0, -6.0, 1.0, -8.0, 3.0, -10.0, 2.0, 5.0]
-        )
-        so, batch_pooled = self.get_select_output_and_batch_pooled(batch_data)
-
-        connector = SparseConnect(normalize_edge_weight=True)
-        edge_index, edge_weight = connector(
-            batch_data.edge_index,
-            so,
-            edge_weight=batch_data.edge_weight,
-            batch_pooled=batch_pooled,
-        )
-
-        if edge_weight is not None:
-            # Should preserve signs and normalize by absolute maximum
-            assert edge_weight.abs().max() <= 1.0 + 1e-6
-            # Check that signs are preserved (if original had negatives, normalized should too)
-            orig_has_negative = (batch_data.edge_weight < 0).any()
-            norm_has_negative = (edge_weight < 0).any()
-            if orig_has_negative:
-                assert norm_has_negative
-
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_mincut_loss.py
+++ b/tests/test_mincut_loss.py
@@ -1,0 +1,197 @@
+"""Comprehensive test suite for MinCut loss implementation with isolated nodes.
+
+Tests the mincut_loss function with various scenarios including isolated nodes,
+which is important for robust pooling operations.
+"""
+
+import pytest
+import torch
+
+from tgp.utils.losses import mincut_loss
+
+
+class TestMinCutLoss:
+    """Test MinCut loss computation with various graph configurations."""
+
+    def test_mincut_loss_basic(self):
+        """Test basic MinCut loss computation."""
+        torch.manual_seed(42)
+
+        # Create simple batch with 2 graphs, 3 nodes each, 2 clusters
+        B, N, K = 2, 3, 2
+
+        # Create adjacency matrices (dense format)
+        adj = torch.rand(B, N, N)
+        adj = adj + adj.transpose(-2, -1)  # Make symmetric
+        # Remove self-loops for each batch
+        for b in range(B):
+            adj[b].fill_diagonal_(0)
+
+        # Create cluster assignment matrix S
+        S = torch.randn(B, N, K)
+        S = torch.softmax(S, dim=-1)  # Normalize to probabilities
+
+        # Create pooled adjacency matrix
+        adj_pooled = torch.matmul(torch.matmul(S.transpose(-2, -1), adj), S)
+
+        # Compute loss
+        loss = mincut_loss(adj, S, adj_pooled, batch_reduction="mean")
+
+        # Check output
+        assert isinstance(loss, torch.Tensor)
+        assert loss.dim() == 0  # Scalar
+        assert torch.isfinite(loss)
+
+    def test_mincut_loss_with_isolated_nodes(self):
+        """Test MinCut loss with isolated nodes."""
+        torch.manual_seed(123)
+
+        # Create batch with isolated nodes
+        B, N, K = 1, 5, 3  # 5 nodes, 3 clusters
+
+        # Create adjacency matrix with isolated nodes
+        # Nodes 0-2 form a triangle, nodes 3-4 are isolated
+        adj = torch.zeros(B, N, N)
+        adj[0, 0, 1] = adj[0, 1, 0] = 1.0  # Edge 0-1
+        adj[0, 1, 2] = adj[0, 2, 1] = 1.0  # Edge 1-2
+        adj[0, 2, 0] = adj[0, 0, 2] = 1.0  # Edge 2-0
+        # Nodes 3 and 4 have no edges (isolated)
+
+        # Create cluster assignment matrix S
+        S = torch.randn(B, N, K)
+        S = torch.softmax(S, dim=-1)  # Normalize to probabilities
+
+        # Create pooled adjacency matrix
+        adj_pooled = torch.matmul(torch.matmul(S.transpose(-2, -1), adj), S)
+
+        # Compute loss
+        loss = mincut_loss(adj, S, adj_pooled, batch_reduction="mean")
+
+        # Check output is valid
+        assert isinstance(loss, torch.Tensor)
+        assert loss.dim() == 0  # Scalar
+        assert torch.isfinite(loss)
+
+        # Test that the loss handles isolated nodes correctly
+        # Isolated nodes should contribute to the degree matrix with zero degree
+        # This tests the robustness of the mincut loss computation
+
+    def test_mincut_loss_all_isolated_nodes(self):
+        """Test MinCut loss when all nodes are isolated (no edges)."""
+        torch.manual_seed(456)
+
+        B, N, K = 1, 4, 2
+
+        # Create adjacency matrix with no edges (all nodes isolated)
+        adj = torch.zeros(B, N, N)
+
+        # Create cluster assignment matrix S
+        S = torch.randn(B, N, K)
+        S = torch.softmax(S, dim=-1)  # Normalize to probabilities
+
+        # Create pooled adjacency matrix (will be all zeros)
+        adj_pooled = torch.matmul(torch.matmul(S.transpose(-2, -1), adj), S)
+
+        # Compute loss
+        loss = mincut_loss(adj, S, adj_pooled, batch_reduction="mean")
+
+        # With no edges, the numerator (trace of adj_pooled) will be 0
+        # The denominator (trace of S^T D S) will also be 0 since D is zero matrix
+        # The loss function adds epsilon to prevent division by zero
+        assert isinstance(loss, torch.Tensor)
+        assert loss.dim() == 0  # Scalar
+        assert torch.isfinite(loss)
+
+    def test_mincut_loss_batch_reduction(self):
+        """Test MinCut loss with different batch reduction methods."""
+        torch.manual_seed(789)
+
+        B, N, K = 3, 4, 2
+
+        # Create adjacency matrices with some isolated nodes
+        adj = torch.zeros(B, N, N)
+        # First graph: chain 0-1-2, node 3 isolated
+        adj[0, 0, 1] = adj[0, 1, 0] = 1.0
+        adj[0, 1, 2] = adj[0, 2, 1] = 1.0
+        # Second graph: single edge 0-1, nodes 2-3 isolated
+        adj[1, 0, 1] = adj[1, 1, 0] = 1.0
+        # Third graph: all nodes isolated
+        # (adj[2] remains zeros)
+
+        # Create cluster assignment matrix S
+        S = torch.randn(B, N, K)
+        S = torch.softmax(S, dim=-1)  # Normalize to probabilities
+
+        # Create pooled adjacency matrix
+        adj_pooled = torch.matmul(torch.matmul(S.transpose(-2, -1), adj), S)
+
+        # Test mean reduction
+        loss_mean = mincut_loss(adj, S, adj_pooled, batch_reduction="mean")
+
+        # Test sum reduction
+        loss_sum = mincut_loss(adj, S, adj_pooled, batch_reduction="sum")
+
+        # Check outputs
+        assert isinstance(loss_mean, torch.Tensor)
+        assert isinstance(loss_sum, torch.Tensor)
+        assert loss_mean.dim() == 0  # Scalar
+        assert loss_sum.dim() == 0  # Scalar
+        assert torch.isfinite(loss_mean)
+        assert torch.isfinite(loss_sum)
+
+        # Sum should be larger than mean (unless all losses are the same)
+        # Note: This might not always hold due to epsilon handling, so we just check they're different
+        # unless the batch losses are identical
+
+    def test_mincut_loss_gradient_flow(self):
+        """Test that gradients flow through MinCut loss."""
+        torch.manual_seed(42)
+
+        B, N, K = 1, 4, 2
+
+        # Create adjacency matrix with isolated nodes
+        adj = torch.zeros(B, N, N)
+        adj[0, 0, 1] = adj[0, 1, 0] = 1.0  # Only one edge, nodes 2-3 isolated
+
+        # Create cluster assignment matrix S (requires grad)
+        S_raw = torch.randn(B, N, K, requires_grad=True)
+        S = torch.softmax(S_raw, dim=-1)  # Normalize to probabilities
+
+        # Create pooled adjacency matrix
+        adj_pooled = torch.matmul(torch.matmul(S.transpose(-2, -1), adj), S)
+
+        # Compute loss
+        loss = mincut_loss(adj, S, adj_pooled, batch_reduction="mean")
+
+        # Backward pass
+        loss.backward()
+
+        # Check gradients exist and are finite
+        assert S_raw.grad is not None
+        assert torch.isfinite(S_raw.grad).all()
+
+    def test_mincut_loss_edge_cases(self):
+        """Test MinCut loss edge cases."""
+        torch.manual_seed(111)
+
+        # Test with single node (isolated by definition)
+        B, N, K = 1, 1, 1
+        adj = torch.zeros(B, N, N)
+        S = torch.ones(B, N, K)  # Single assignment
+        adj_pooled = torch.zeros(B, K, K)
+
+        loss = mincut_loss(adj, S, adj_pooled, batch_reduction="mean")
+        assert torch.isfinite(loss)
+
+        # Test with two isolated nodes
+        B, N, K = 1, 2, 1
+        adj = torch.zeros(B, N, N)
+        S = torch.ones(B, N, K)  # Both nodes to same cluster
+        adj_pooled = torch.zeros(B, K, K)
+
+        loss = mincut_loss(adj, S, adj_pooled, batch_reduction="mean")
+        assert torch.isfinite(loss)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tgp/connect/__init__.py
+++ b/tgp/connect/__init__.py
@@ -1,5 +1,5 @@
 from .base_conn import Connect, SparseConnect, sparse_connect
-from .dense_conn import DenseConnect, dense_connect, postprocess_adj_pool
+from .dense_conn import DenseConnect
 from .dense_conn_spt import DenseConnectSPT
 from .kron_conn import KronConnect
 

--- a/tgp/connect/base_conn.py
+++ b/tgp/connect/base_conn.py
@@ -60,7 +60,7 @@ def sparse_connect(
     num_supernodes: int = None,
     remove_self_loops: bool = True,
     reduce_op: ConnectionType = "sum",
-    normalize_edge_weight: bool = False,
+    edge_weight_norm: bool = False,
     batch_pooled: Optional[Tensor] = None,
     degree_norm: bool = False,
 ) -> Tuple[Adj, OptTensor]:
@@ -100,7 +100,7 @@ def sparse_connect(
             edge_weight * deg_inv_sqrt[edge_index[0]] * deg_inv_sqrt[edge_index[1]]
         )
 
-    if normalize_edge_weight and edge_weight is not None:
+    if edge_weight_norm and edge_weight is not None:
         # Per-graph normalization using batch_pooled
         edge_batch = batch_pooled[edge_index[0]]
 
@@ -148,7 +148,7 @@ class SparseConnect(Connect):
         remove_self_loops (bool, optional):
             Whether to remove self-loops from the graph after coarsening.
             (default: :obj:`True`)
-        normalize_edge_weight (bool, optional):
+        edge_weight_norm (bool, optional):
             Whether to normalize the edge weights by dividing by the maximum absolute value
             per graph.
             (default: :obj:`False`)
@@ -162,13 +162,13 @@ class SparseConnect(Connect):
         self,
         reduce_op: ConnectionType = "sum",
         remove_self_loops: bool = True,
-        normalize_edge_weight: bool = False,
+        edge_weight_norm: bool = False,
         degree_norm: bool = False,
     ):
         super().__init__()
         self.reduce_op = reduce_op
         self.remove_self_loops = remove_self_loops
-        self.normalize_edge_weight = normalize_edge_weight
+        self.edge_weight_norm = edge_weight_norm
         self.degree_norm = degree_norm
 
     def forward(
@@ -195,7 +195,7 @@ class SparseConnect(Connect):
                 (default: :obj:`None`)
             batch_pooled (~torch.Tensor, optional):
                 Batch vector which assigns each supernode to a specific graph.
-                Required when normalize_edge_weight=True for per-graph normalization.
+                Required when edge_weight_norm=True for per-graph normalization.
                 (default: :obj:`None`)
 
         Returns:
@@ -204,9 +204,9 @@ class SparseConnect(Connect):
             If the pooled adjacency is a :obj:`~torch_sparse.SparseTensor`,
             returns :obj:`None` as the edge weights.
         """
-        if self.normalize_edge_weight and batch_pooled is None:
+        if self.edge_weight_norm and batch_pooled is None:
             raise AssertionError(
-                "normalize_edge_weight=True but batch_pooled=None. "
+                "edge_weight_norm=True but batch_pooled=None. "
                 "batch_pooled parameter is required for per-graph normalization in SparseConnect."
             )
 
@@ -219,7 +219,7 @@ class SparseConnect(Connect):
             num_supernodes=so.num_supernodes,
             remove_self_loops=self.remove_self_loops,
             reduce_op=self.reduce_op,
-            normalize_edge_weight=self.normalize_edge_weight,
+            edge_weight_norm=self.edge_weight_norm,
             batch_pooled=batch_pooled,
             degree_norm=self.degree_norm,
         )
@@ -231,6 +231,6 @@ class SparseConnect(Connect):
             f"{self.__class__.__name__}("
             f"reduce_op={self.reduce_op}, "
             f"remove_self_loops={self.remove_self_loops}, "
-            f"normalize_edge_weight={self.normalize_edge_weight}, "
+            f"edge_weight_norm={self.edge_weight_norm}, "
             f"degree_norm={self.degree_norm})"
         )

--- a/tgp/connect/base_conn.py
+++ b/tgp/connect/base_conn.py
@@ -136,7 +136,7 @@ class SparseConnect(Connect):
             (default: :obj:`True`)
         normalize_edge_weight (bool, optional):
             Whether to normalize the edge weights by dividing by the maximum absolute value
-            per graph (if batch_pooled is provided) or globally (if batch_pooled is None).
+            per graph.
             (default: :obj:`False`)
     """
 

--- a/tgp/connect/dense_conn.py
+++ b/tgp/connect/dense_conn.py
@@ -92,7 +92,7 @@ class DenseConnect(Connect):
             message passing layers.
             (default: :obj:`True`)
         normalize_edge_weight (bool, optional):
-            Whether to normalize the edge weights by dividing by the maximum absolute value.
+            Whether to normalize the edge weights by dividing by the maximum absolute value per graph.
             (default: :obj:`False`)
     """
 

--- a/tgp/connect/dense_conn.py
+++ b/tgp/connect/dense_conn.py
@@ -52,22 +52,17 @@ def postprocess_adj_pool(
     if normalize_edge_weight:
         # Per-graph normalization for dense adjacency matrices
         # adj_pool has shape [batch_size, num_supernodes, num_supernodes]
-        if adj_pool.dim() == 3:  # batched case
-            batch_size = adj_pool.size(0)
-            # Find max absolute value per graph: [batch_size, 1, 1]
-            max_per_graph = (
-                adj_pool.view(batch_size, -1).abs().max(dim=1, keepdim=True)[0]
-            )
-            max_per_graph = max_per_graph.unsqueeze(-1)  # [batch_size, 1, 1]
+        batch_size = adj_pool.size(0)
+        # Find max absolute value per graph: [batch_size, 1, 1]
+        max_per_graph = adj_pool.view(batch_size, -1).abs().max(dim=1, keepdim=True)[0]
+        max_per_graph = max_per_graph.unsqueeze(-1)  # [batch_size, 1, 1]
 
-            # Avoid division by zero
-            max_per_graph = torch.where(
-                max_per_graph == 0, torch.ones_like(max_per_graph), max_per_graph
-            )
+        # Avoid division by zero
+        max_per_graph = torch.where(
+            max_per_graph == 0, torch.ones_like(max_per_graph), max_per_graph
+        )
 
-            adj_pool = adj_pool / max_per_graph
-        else:  # single graph case
-            adj_pool = adj_pool / adj_pool.abs().max()
+        adj_pool = adj_pool / max_per_graph
 
     return adj_pool
 

--- a/tgp/connect/dense_conn.py
+++ b/tgp/connect/dense_conn.py
@@ -5,68 +5,6 @@ from tgp.connect import Connect
 from tgp.select import SelectOutput
 
 
-def dense_connect(
-    s: Tensor,
-    adj: Tensor,
-    remove_self_loops: bool = False,
-    degree_norm: bool = False,
-    adj_transpose: bool = False,
-    normalize_edge_weight: bool = False,
-) -> Tensor:
-    r"""Connects the nodes in the coarsened graph for dense pooling methods."""
-    sta = torch.matmul(s.transpose(-2, -1), adj)
-    adj_pool = torch.matmul(sta, s)
-    adj_pool = postprocess_adj_pool(
-        adj_pool,
-        remove_self_loops=remove_self_loops,
-        degree_norm=degree_norm,
-        adj_transpose=adj_transpose,
-        normalize_edge_weight=normalize_edge_weight,
-    )
-
-    return adj_pool
-
-
-def postprocess_adj_pool(
-    adj_pool: Tensor,
-    remove_self_loops: bool = False,
-    degree_norm: bool = False,
-    adj_transpose: bool = False,
-    normalize_edge_weight: bool = False,
-) -> Tensor:
-    r"""Postprocess the adjacency matrix of the pooled graph."""
-    if remove_self_loops:
-        torch.diagonal(adj_pool, dim1=-2, dim2=-1)[:] = 0
-
-    if degree_norm:
-        if adj_transpose:
-            # For the transposed output the "row" sum is along axis -2
-            d = adj_pool.sum(-2, keepdim=True)
-        else:
-            # Compute row sums along the last dimension.
-            d = adj_pool.sum(-1, keepdim=True)
-        d[d == 0] = 1  # avoid division by zero
-        d = torch.sqrt(d)
-        adj_pool = (adj_pool / d) / d.transpose(-2, -1)
-
-    if normalize_edge_weight:
-        # Per-graph normalization for dense adjacency matrices
-        # adj_pool has shape [batch_size, num_supernodes, num_supernodes]
-        batch_size = adj_pool.size(0)
-        # Find max absolute value per graph: [batch_size, 1, 1]
-        max_per_graph = adj_pool.view(batch_size, -1).abs().max(dim=1, keepdim=True)[0]
-        max_per_graph = max_per_graph.unsqueeze(-1)  # [batch_size, 1, 1]
-
-        # Avoid division by zero
-        max_per_graph = torch.where(
-            max_per_graph == 0, torch.ones_like(max_per_graph), max_per_graph
-        )
-
-        adj_pool = adj_pool / max_per_graph
-
-    return adj_pool
-
-
 class DenseConnect(Connect):
     r"""The :math:`\texttt{connect}` operator for *dense* pooling methods.
 
@@ -91,7 +29,7 @@ class DenseConnect(Connect):
             adjacency matrix, so that it can be passed "as is" to the dense
             message passing layers.
             (default: :obj:`True`)
-        normalize_edge_weight (bool, optional):
+        edge_weight_norm (bool, optional):
             Whether to normalize the edge weights by dividing by the maximum absolute value per graph.
             (default: :obj:`False`)
     """
@@ -101,13 +39,67 @@ class DenseConnect(Connect):
         remove_self_loops: bool = True,
         degree_norm: bool = True,
         adj_transpose: bool = True,
-        normalize_edge_weight: bool = False,
+        edge_weight_norm: bool = False,
     ):
         super().__init__()
         self.remove_self_loops = remove_self_loops
         self.degree_norm = degree_norm
         self.adj_transpose = adj_transpose
-        self.normalize_edge_weight = normalize_edge_weight
+        self.edge_weight_norm = edge_weight_norm
+
+    @classmethod
+    def dense_connect(
+        cls,
+        s: Tensor,
+        adj: Tensor,
+    ) -> Tensor:
+        r"""Connects the nodes in the coarsened graph for dense pooling methods."""
+        sta = torch.matmul(s.transpose(-2, -1), adj)
+        adj_pool = torch.matmul(sta, s)
+        return adj_pool
+
+    @classmethod
+    def postprocess_adj_pool(
+        cls,
+        adj_pool: Tensor,
+        remove_self_loops: bool = False,
+        degree_norm: bool = False,
+        adj_transpose: bool = False,
+        edge_weight_norm: bool = False,
+    ) -> Tensor:
+        r"""Postprocess the adjacency matrix of the pooled graph."""
+        if remove_self_loops:
+            torch.diagonal(adj_pool, dim1=-2, dim2=-1)[:] = 0
+
+        if degree_norm:
+            if adj_transpose:
+                # For the transposed output the "row" sum is along axis -2
+                d = adj_pool.sum(-2, keepdim=True)
+            else:
+                # Compute row sums along the last dimension.
+                d = adj_pool.sum(-1, keepdim=True)
+            d[d == 0] = 1  # avoid division by zero
+            d = torch.sqrt(d)
+            adj_pool = (adj_pool / d) / d.transpose(-2, -1)
+
+        if edge_weight_norm:
+            # Per-graph normalization for dense adjacency matrices
+            # adj_pool has shape [batch_size, num_supernodes, num_supernodes]
+            batch_size = adj_pool.size(0)
+            # Find max absolute value per graph: [batch_size, 1, 1]
+            max_per_graph = (
+                adj_pool.view(batch_size, -1).abs().max(dim=1, keepdim=True)[0]
+            )
+            max_per_graph = max_per_graph.unsqueeze(-1)  # [batch_size, 1, 1]
+
+            # Avoid division by zero
+            max_per_graph = torch.where(
+                max_per_graph == 0, torch.ones_like(max_per_graph), max_per_graph
+            )
+
+            adj_pool = adj_pool / max_per_graph
+
+        return adj_pool
 
     def forward(self, edge_index: Tensor, so: SelectOutput, **kwargs) -> Tensor:
         r"""Forward pass.
@@ -128,13 +120,14 @@ class DenseConnect(Connect):
         """
         assert isinstance(so.s, Tensor), "SelectOutput.s must be a tensor"
 
-        adj_pool = dense_connect(
-            so.s,
-            edge_index,
+        adj_pool = self.dense_connect(so.s, edge_index)
+
+        adj_pool = self.postprocess_adj_pool(
+            adj_pool,
             remove_self_loops=self.remove_self_loops,
             degree_norm=self.degree_norm,
             adj_transpose=self.adj_transpose,
-            normalize_edge_weight=self.normalize_edge_weight,
+            edge_weight_norm=self.edge_weight_norm,
         )
 
         return adj_pool, None
@@ -145,5 +138,5 @@ class DenseConnect(Connect):
             f"remove_self_loops={self.remove_self_loops}, "
             f"degree_norm={self.degree_norm}, "
             f"adj_transpose={self.adj_transpose}, "
-            f"normalize_edge_weight={self.normalize_edge_weight})"
+            f"edge_weight_norm={self.edge_weight_norm})"
         )

--- a/tgp/connect/dense_conn_spt.py
+++ b/tgp/connect/dense_conn_spt.py
@@ -30,7 +30,7 @@ class DenseConnectSPT(Connect):
             If :obj:`True`, the adjacency matrix will be symmetrically normalized.
             (default: :obj:`True`)
         normalize_edge_weight (bool, optional):
-            Whether to normalize the edge weights by dividing by the maximum absolute value.
+            Whether to normalize the edge weights by dividing by the maximum absolute value per graph.
             (default: :obj:`False`)
     """
 

--- a/tgp/connect/dense_conn_spt.py
+++ b/tgp/connect/dense_conn_spt.py
@@ -29,7 +29,7 @@ class DenseConnectSPT(Connect):
         degree_norm (bool, optional):
             If :obj:`True`, the adjacency matrix will be symmetrically normalized.
             (default: :obj:`True`)
-        normalize_edge_weight (bool, optional):
+        edge_weight_norm (bool, optional):
             Whether to normalize the edge weights by dividing by the maximum absolute value per graph.
             (default: :obj:`False`)
     """
@@ -38,13 +38,13 @@ class DenseConnectSPT(Connect):
         self,
         remove_self_loops: bool = True,
         degree_norm: bool = False,
-        normalize_edge_weight: bool = False,
+        edge_weight_norm: bool = False,
     ):
         super().__init__()
 
         self.remove_self_loops = remove_self_loops
         self.degree_norm = degree_norm
-        self.normalize_edge_weight = normalize_edge_weight
+        self.edge_weight_norm = edge_weight_norm
 
     def forward(
         self,
@@ -70,7 +70,7 @@ class DenseConnectSPT(Connect):
                 The output of the :math:`\texttt{select}` operator.
             batch_pooled (~torch.Tensor, optional):
                 Batch vector which assigns each supernode to a specific graph.
-                Required when normalize_edge_weight=True for per-graph normalization.
+                Required when edge_weight_norm=True for per-graph normalization.
                 (default: :obj:`None`)
 
         Returns:
@@ -79,9 +79,9 @@ class DenseConnectSPT(Connect):
             If the pooled adjacency is a :obj:`~torch_sparse.SparseTensor`,
             returns :obj:`None` as the edge weights.
         """
-        if self.normalize_edge_weight and batch_pooled is None:
+        if self.edge_weight_norm and batch_pooled is None:
             raise AssertionError(
-                "normalize_edge_weight=True but batch_pooled=None. "
+                "edge_weight_norm=True but batch_pooled=None. "
                 "batch_pooled parameter is required for per-graph normalization in DenseConnectSPT."
             )
         if isinstance(edge_index, SparseTensor):
@@ -120,7 +120,7 @@ class DenseConnectSPT(Connect):
                 row=row, col=col, value=val, sparse_sizes=adj_pooled.sparse_sizes()
             ).coalesce()
 
-        if self.normalize_edge_weight:
+        if self.edge_weight_norm:
             # Use batch_pooled to map edges to graphs
             edge_batch = batch_pooled[row]
 
@@ -152,5 +152,5 @@ class DenseConnectSPT(Connect):
             f"{self.__class__.__name__}("
             f"remove_self_loops={self.remove_self_loops}, "
             f"degree_norm={self.degree_norm}, "
-            f"normalize_edge_weight={self.normalize_edge_weight})"
+            f"edge_weight_norm={self.edge_weight_norm})"
         )

--- a/tgp/connect/dense_conn_spt.py
+++ b/tgp/connect/dense_conn_spt.py
@@ -1,7 +1,9 @@
 from typing import Optional, Tuple
 
+import torch
 from torch import Tensor
 from torch_geometric.typing import Adj
+from torch_scatter import scatter
 from torch_sparse import SparseTensor
 
 from tgp.connect import Connect
@@ -27,19 +29,29 @@ class DenseConnectSPT(Connect):
         degree_norm (bool, optional):
             If :obj:`True`, the adjacency matrix will be symmetrically normalized.
             (default: :obj:`True`)
+        normalize_edge_weight (bool, optional):
+            Whether to normalize the edge weights by dividing by the maximum absolute value.
+            (default: :obj:`False`)
     """
 
-    def __init__(self, remove_self_loops: bool = True, degree_norm: bool = False):
+    def __init__(
+        self,
+        remove_self_loops: bool = True,
+        degree_norm: bool = False,
+        normalize_edge_weight: bool = False,
+    ):
         super().__init__()
 
         self.remove_self_loops = remove_self_loops
         self.degree_norm = degree_norm
+        self.normalize_edge_weight = normalize_edge_weight
 
     def forward(
         self,
         edge_index: Adj,
         edge_weight: Optional[Tensor] = None,
         so: SelectOutput = None,
+        batch_pool: Optional[Tensor] = None,
         **kwargs,
     ) -> Tuple[Adj, Optional[Tensor]]:
         r"""Forward pass.
@@ -56,6 +68,10 @@ class DenseConnectSPT(Connect):
                 (default: :obj:`None`)
             so (~tgp.select.SelectOutput):
                 The output of the :math:`\texttt{select}` operator.
+            batch_pool (~torch.Tensor, optional):
+                Batch vector which assigns each supernode to a specific graph.
+                Required when normalize_edge_weight=True for per-graph normalization.
+                (default: :obj:`None`)
 
         Returns:
             (~torch_geometric.typing.Adj, ~torch.Tensor or None):
@@ -63,6 +79,11 @@ class DenseConnectSPT(Connect):
             If the pooled adjacency is a :obj:`~torch_sparse.SparseTensor`,
             returns :obj:`None` as the edge weights.
         """
+        if self.normalize_edge_weight and batch_pool is None:
+            raise AssertionError(
+                "normalize_edge_weight=True but batch_pool=None. "
+                "batch_pool parameter is required for per-graph normalization in DenseConnectSPT."
+            )
         if isinstance(edge_index, SparseTensor):
             adj_pooled = so.s.t() @ edge_index @ so.s
         elif isinstance(edge_index, Tensor):
@@ -99,6 +120,25 @@ class DenseConnectSPT(Connect):
                 row=row, col=col, value=val, sparse_sizes=adj_pooled.sparse_sizes()
             ).coalesce()
 
+        if self.normalize_edge_weight:
+            # Use batch_pool to map edges to graphs
+            edge_batch = batch_pool[row]
+
+            # Find maximum absolute value per graph
+            max_per_graph = scatter(val.abs(), edge_batch, dim=0, reduce="max")
+
+            # Avoid division by zero
+            max_per_graph = torch.where(
+                max_per_graph == 0, torch.ones_like(max_per_graph), max_per_graph
+            )
+
+            # Normalize values by their respective graph's maximum
+            val = val / max_per_graph[edge_batch]
+
+            adj_pooled = SparseTensor(
+                row=row, col=col, value=val, sparse_sizes=adj_pooled.sparse_sizes()
+            ).coalesce()
+
         # Convert back to edge index if needed
         if isinstance(edge_index, Tensor):
             adj_pooled, edge_weight = connectivity_to_edge_index(
@@ -111,5 +151,6 @@ class DenseConnectSPT(Connect):
         return (
             f"{self.__class__.__name__}("
             f"remove_self_loops={self.remove_self_loops}, "
-            f"degree_norm={self.degree_norm})"
+            f"degree_norm={self.degree_norm}, "
+            f"normalize_edge_weight={self.normalize_edge_weight})"
         )

--- a/tgp/connect/dense_conn_spt.py
+++ b/tgp/connect/dense_conn_spt.py
@@ -51,7 +51,7 @@ class DenseConnectSPT(Connect):
         edge_index: Adj,
         edge_weight: Optional[Tensor] = None,
         so: SelectOutput = None,
-        batch_pool: Optional[Tensor] = None,
+        batch_pooled: Optional[Tensor] = None,
         **kwargs,
     ) -> Tuple[Adj, Optional[Tensor]]:
         r"""Forward pass.
@@ -68,7 +68,7 @@ class DenseConnectSPT(Connect):
                 (default: :obj:`None`)
             so (~tgp.select.SelectOutput):
                 The output of the :math:`\texttt{select}` operator.
-            batch_pool (~torch.Tensor, optional):
+            batch_pooled (~torch.Tensor, optional):
                 Batch vector which assigns each supernode to a specific graph.
                 Required when normalize_edge_weight=True for per-graph normalization.
                 (default: :obj:`None`)
@@ -79,10 +79,10 @@ class DenseConnectSPT(Connect):
             If the pooled adjacency is a :obj:`~torch_sparse.SparseTensor`,
             returns :obj:`None` as the edge weights.
         """
-        if self.normalize_edge_weight and batch_pool is None:
+        if self.normalize_edge_weight and batch_pooled is None:
             raise AssertionError(
-                "normalize_edge_weight=True but batch_pool=None. "
-                "batch_pool parameter is required for per-graph normalization in DenseConnectSPT."
+                "normalize_edge_weight=True but batch_pooled=None. "
+                "batch_pooled parameter is required for per-graph normalization in DenseConnectSPT."
             )
         if isinstance(edge_index, SparseTensor):
             adj_pooled = so.s.t() @ edge_index @ so.s
@@ -121,8 +121,8 @@ class DenseConnectSPT(Connect):
             ).coalesce()
 
         if self.normalize_edge_weight:
-            # Use batch_pool to map edges to graphs
-            edge_batch = batch_pool[row]
+            # Use batch_pooled to map edges to graphs
+            edge_batch = batch_pooled[row]
 
             # Find maximum absolute value per graph
             max_per_graph = scatter(val.abs(), edge_batch, dim=0, reduce="max")

--- a/tgp/poolers/asym_cheeger_cut.py
+++ b/tgp/poolers/asym_cheeger_cut.py
@@ -49,6 +49,9 @@ class AsymCheegerCutPooling(DenseSRCPooling):
         degree_norm (bool, optional):
             If :obj:`True`, the adjacency matrix will be symmetrically normalized.
             (default: :obj:`True`)
+        edge_weight_norm (bool, optional):
+            Whether to normalize the edge weights by dividing by the maximum absolute value per graph.
+            (default: :obj:`False`)
         adj_transpose (bool, optional):
             If :obj:`True`, the preprocessing step in :class:`~tgp.src.DenseSRCPooling` and
             the :class:`~tgp.connect.DenseConnect` operation returns transposed
@@ -85,6 +88,7 @@ class AsymCheegerCutPooling(DenseSRCPooling):
         balance_coeff: float = 1.0,
         remove_self_loops: bool = True,
         degree_norm: bool = True,
+        edge_weight_norm: bool = False,
         adj_transpose: bool = True,
         lift: LiftType = "precomputed",
         s_inv_op: SinvType = "transpose",
@@ -103,6 +107,7 @@ class AsymCheegerCutPooling(DenseSRCPooling):
                 remove_self_loops=remove_self_loops,
                 degree_norm=degree_norm,
                 adj_transpose=adj_transpose,
+                edge_weight_norm=edge_weight_norm,
             ),
             adj_transpose=adj_transpose,
         )

--- a/tgp/poolers/diffpool.py
+++ b/tgp/poolers/diffpool.py
@@ -55,6 +55,9 @@ class DiffPool(DenseSRCPooling):
         degree_norm (bool, optional):
             If :obj:`True`, the adjacency matrix will be symmetrically normalized.
             (default: :obj:`True`)
+        edge_weight_norm (bool, optional):
+            Whether to normalize the edge weights by dividing by the maximum absolute value per graph.
+            (default: :obj:`False`)
         adj_transpose (bool, optional):
             If :obj:`True`, the preprocessing step in :class:`~tgp.src.DenseSRCPooling` and
             the :class:`~tgp.connect.DenseConnect` operation returns transposed
@@ -92,6 +95,7 @@ class DiffPool(DenseSRCPooling):
         normalize_loss: bool = False,
         remove_self_loops: bool = True,
         degree_norm: bool = True,
+        edge_weight_norm: bool = False,
         adj_transpose: bool = True,
         lift: LiftType = "precomputed",
         s_inv_op: SinvType = "transpose",
@@ -110,6 +114,7 @@ class DiffPool(DenseSRCPooling):
                 remove_self_loops=remove_self_loops,
                 degree_norm=degree_norm,
                 adj_transpose=adj_transpose,
+                edge_weight_norm=edge_weight_norm,
             ),
             adj_transpose=adj_transpose,
         )

--- a/tgp/poolers/dmon.py
+++ b/tgp/poolers/dmon.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Union
 
 from torch import Tensor
 
-from tgp.connect import DenseConnect, postprocess_adj_pool
+from tgp.connect import DenseConnect
 from tgp.lift import BaseLift
 from tgp.reduce import BaseReduce
 from tgp.select import DenseSelect, SelectOutput
@@ -47,6 +47,15 @@ class DMoNPooling(DenseSRCPooling):
         ortho_loss_coeff (float, optional):
             Coefficient for the orthogonality loss. This loss does not appear in the original paper.
             (default: :obj:`0.0`)
+        remove_self_loops (bool, optional):
+            If :obj:`True`, the self-loops will be removed from the adjacency matrix.
+            (default: :obj:`True`)
+        degree_norm (bool, optional):
+            If :obj:`True`, the adjacency matrix will be symmetrically normalized.
+            (default: :obj:`True`)
+        edge_weight_norm (bool, optional):
+            Whether to normalize the edge weights by dividing by the maximum absolute value per graph.
+            (default: :obj:`False`)
         adj_transpose (bool, optional):
             If :obj:`True`, the preprocessing step in :class:`~tgp.src.DenseSRCPooling` and
             the :class:`~tgp.connect.DenseConnect` operation returns transposed
@@ -82,6 +91,9 @@ class DMoNPooling(DenseSRCPooling):
         spectral_loss_coeff: float = 1.0,
         cluster_loss_coeff: float = 1.0,
         ortho_loss_coeff: float = 0.0,
+        remove_self_loops: bool = True,
+        degree_norm: bool = True,
+        edge_weight_norm: bool = False,
         adj_transpose: bool = True,
         lift: LiftType = "precomputed",
         s_inv_op: SinvType = "transpose",
@@ -97,7 +109,10 @@ class DMoNPooling(DenseSRCPooling):
             reducer=BaseReduce(),
             lifter=BaseLift(matrix_op=lift),
             connector=DenseConnect(
-                remove_self_loops=False, degree_norm=False, adj_transpose=adj_transpose
+                remove_self_loops=remove_self_loops,
+                degree_norm=degree_norm,
+                adj_transpose=adj_transpose,
+                edge_weight_norm=edge_weight_norm,
             ),
             adj_transpose=adj_transpose,
         )
@@ -148,16 +163,17 @@ class DMoNPooling(DenseSRCPooling):
             x_pooled, _ = self.reduce(x=x, so=so)
 
             # Connect
-            adj_pool, _ = self.connect(edge_index=adj, so=so)
+            adj_pool = self.connector.dense_connect(adj=adj, s=so.s)
 
             loss = self.compute_loss(adj, so.s, adj_pool, mask)
 
             # Normalize coarsened adjacency matrix
-            adj_pool = postprocess_adj_pool(
+            adj_pool = self.connector.postprocess_adj_pool(
                 adj_pool,
-                remove_self_loops=True,
-                degree_norm=True,
-                adj_transpose=self.adj_transpose,
+                remove_self_loops=self.connector.remove_self_loops,
+                degree_norm=self.connector.degree_norm,
+                adj_transpose=self.connector.adj_transpose,
+                edge_weight_norm=self.connector.edge_weight_norm,
             )
 
             out = PoolingOutput(x=x_pooled, edge_index=adj_pool, so=so, loss=loss)

--- a/tgp/poolers/edge_contraction.py
+++ b/tgp/poolers/edge_contraction.py
@@ -69,7 +69,6 @@ class EdgeContractionPooling(SRCPooling):
             The operation used to compute :math:`\mathbf{S}_\text{inv}` from the select matrix
             :math:`\mathbf{S}`. :math:`\mathbf{S}_\text{inv}` is stored in the :obj:`"s_inv"` attribute of
             the :class:`~tgp.select.SelectOutput`. It can be one of:
-
             - :obj:`"transpose"` (default): Computes :math:`\mathbf{S}_\text{inv}` as :math:`\mathbf{S}^\top`,
               the transpose of :math:`\mathbf{S}`.
             - :obj:`"inverse"`: Computes :math:`\mathbf{S}_\text{inv}` as :math:`\mathbf{S}^+`,
@@ -93,8 +92,14 @@ class EdgeContractionPooling(SRCPooling):
             e.g., :obj:`'sum'`, :obj:`'mean'`, :obj:`'max'`)
             (default: :obj:`"sum"`)
         remove_self_loops (bool, optional):
-            Whether to remove self-loops from the graph after coarsening.
+            If :obj:`True`, the self-loops will be removed from the adjacency matrix.
             (default: :obj:`True`)
+        degree_norm (bool, optional):
+            If :obj:`True`, the adjacency matrix will be symmetrically normalized.
+            (default: :obj:`False`)
+        edge_weight_norm (bool, optional):
+            Whether to normalize the edge weights by dividing by the maximum absolute value per graph.
+            (default: :obj:`False`)
     """
 
     def __init__(
@@ -109,6 +114,8 @@ class EdgeContractionPooling(SRCPooling):
         connect_red_op: ConnectionType = "sum",
         lift_red_op: ReduceType = "sum",
         remove_self_loops: bool = True,
+        degree_norm: bool = False,
+        edge_weight_norm: bool = False,
     ):
         super().__init__(
             selector=EdgeContractionSelect(
@@ -121,7 +128,10 @@ class EdgeContractionPooling(SRCPooling):
             reducer=BaseReduce(reduce_op=reduce_red_op),
             lifter=BaseLift(matrix_op=lift, reduce_op=lift_red_op),
             connector=SparseConnect(
-                reduce_op=connect_red_op, remove_self_loops=remove_self_loops
+                reduce_op=connect_red_op,
+                remove_self_loops=remove_self_loops,
+                degree_norm=degree_norm,
+                edge_weight_norm=edge_weight_norm,
             ),
         )
 
@@ -180,7 +190,10 @@ class EdgeContractionPooling(SRCPooling):
 
             # Connect
             edge_index_pooled, edge_weight_pooled = self.connect(
-                edge_index=adj, so=so, edge_weight=edge_weight
+                edge_index=adj,
+                so=so,
+                edge_weight=edge_weight,
+                batch_pooled=batch_pooled,
             )
 
             out = PoolingOutput(

--- a/tgp/poolers/hosc.py
+++ b/tgp/poolers/hosc.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union
 import torch
 from torch import Tensor
 
-from tgp.connect import DenseConnect, postprocess_adj_pool
+from tgp.connect import DenseConnect
 from tgp.lift import BaseLift
 from tgp.reduce import BaseReduce
 from tgp.select import DenseSelect, SelectOutput
@@ -52,6 +52,15 @@ class HOSCPooling(DenseSRCPooling):
             Specifies either to use the hosc_orthogonality_loss or the
             orthogonality_loss.
             (default: :obj:`False`)
+        remove_self_loops (bool, optional):
+            If :obj:`True`, the self-loops will be removed from the adjacency matrix.
+            (default: :obj:`True`)
+        degree_norm (bool, optional):
+            If :obj:`True`, the adjacency matrix will be symmetrically normalized.
+            (default: :obj:`True`)
+        edge_weight_norm (bool, optional):
+            Whether to normalize the edge weights by dividing by the maximum absolute value per graph.
+            (default: :obj:`False`)
         adj_transpose (bool, optional):
             If :obj:`True`, the preprocessing step in :class:`~tgp.src.DenseSRCPooling` and
             the :class:`~tgp.connect.DenseConnect` operation returns transposed
@@ -87,6 +96,9 @@ class HOSCPooling(DenseSRCPooling):
         mu: float = 0.1,
         alpha: float = 0.5,
         hosc_ortho: bool = False,
+        remove_self_loops: bool = True,
+        degree_norm: bool = True,
+        edge_weight_norm: bool = False,
         adj_transpose: bool = True,
         lift: LiftType = "precomputed",
         s_inv_op: SinvType = "transpose",
@@ -102,7 +114,10 @@ class HOSCPooling(DenseSRCPooling):
             reducer=BaseReduce(),
             lifter=BaseLift(matrix_op=lift),
             connector=DenseConnect(
-                remove_self_loops=False, degree_norm=False, adj_transpose=adj_transpose
+                remove_self_loops=remove_self_loops,
+                degree_norm=degree_norm,
+                adj_transpose=adj_transpose,
+                edge_weight_norm=edge_weight_norm,
             ),
             adj_transpose=adj_transpose,
         )
@@ -154,17 +169,18 @@ class HOSCPooling(DenseSRCPooling):
             x_pooled, _ = self.reduce(x=x, so=so)
 
             # Connect
-            adj_pool, _ = self.connect(edge_index=adj, so=so)
-
-            # Normalize coarsened adjacency matrix
-            adj_pool = postprocess_adj_pool(
-                adj_pool,
-                remove_self_loops=True,
-                degree_norm=True,
-                adj_transpose=self.adj_transpose,
-            )
+            adj_pool = self.connector.dense_connect(adj=adj, s=so.s)
 
             loss = self.compute_loss(adj, so.s, adj_pool, mask)
+
+            # Normalize coarsened adjacency matrix
+            adj_pool = self.connector.postprocess_adj_pool(
+                adj_pool,
+                remove_self_loops=self.connector.remove_self_loops,
+                degree_norm=self.connector.degree_norm,
+                adj_transpose=self.connector.adj_transpose,
+                edge_weight_norm=self.connector.edge_weight_norm,
+            )
 
             out = PoolingOutput(x=x_pooled, edge_index=adj_pool, so=so, loss=loss)
 

--- a/tgp/poolers/just_balance.py
+++ b/tgp/poolers/just_balance.py
@@ -46,6 +46,9 @@ class JustBalancePooling(DenseSRCPooling):
         degree_norm (bool, optional):
             If :obj:`True`, the adjacency matrix will be symmetrically normalized.
             (default: :obj:`True`)
+        edge_weight_norm (bool, optional):
+            Whether to normalize the edge weights by dividing by the maximum absolute value per graph.
+            (default: :obj:`False`)
         adj_transpose (bool, optional):
             If :obj:`True`, the preprocessing step in :class:`~tgp.src.DenseSRCPooling` and
             the :class:`~tgp.connect.DenseConnect` operation returns transposed
@@ -82,6 +85,7 @@ class JustBalancePooling(DenseSRCPooling):
         loss_coeff: float = 1.0,
         remove_self_loops: bool = True,
         degree_norm: bool = True,
+        edge_weight_norm: bool = False,
         adj_transpose: bool = True,
         lift: LiftType = "precomputed",
         s_inv_op: SinvType = "transpose",
@@ -100,6 +104,7 @@ class JustBalancePooling(DenseSRCPooling):
                 remove_self_loops=remove_self_loops,
                 degree_norm=degree_norm,
                 adj_transpose=adj_transpose,
+                edge_weight_norm=edge_weight_norm,
             ),
             adj_transpose=adj_transpose,
         )

--- a/tgp/poolers/kmis.py
+++ b/tgp/poolers/kmis.py
@@ -113,6 +113,12 @@ class KMISPooling(BasePrecoarseningMixin, SRCPooling):
         remove_self_loops (bool, optional):
             Whether to remove self-loops from the graph after coarsening.
             (default: :obj:`True`)
+        degree_norm (bool, optional):
+            If :obj:`True`, the adjacency matrix will be symmetrically normalized.
+            (default: :obj:`False`)
+        edge_weight_norm (bool, optional):
+            Whether to normalize the edge weights by dividing by the maximum absolute value per graph.
+            (default: :obj:`False`)
         cached (bool, optional):
             If set to :obj:`True`, the output of the :math:`\texttt{select}` and :math:`\texttt{select}`
             operations will be cached, so that they do not need to be recomputed.
@@ -135,6 +141,8 @@ class KMISPooling(BasePrecoarseningMixin, SRCPooling):
         connect_red_op: ConnectionType = "sum",
         lift_red_op: ReduceType = "sum",
         remove_self_loops: bool = True,
+        degree_norm: bool = False,
+        edge_weight_norm: bool = False,
         cached: bool = False,
         node_dim: int = -2,
     ):
@@ -153,7 +161,10 @@ class KMISPooling(BasePrecoarseningMixin, SRCPooling):
             ),
             lifter=BaseLift(matrix_op=lift, reduce_op=lift_red_op),
             connector=SparseConnect(
-                reduce_op=connect_red_op, remove_self_loops=remove_self_loops
+                reduce_op=connect_red_op,
+                remove_self_loops=remove_self_loops,
+                degree_norm=degree_norm,
+                edge_weight_norm=edge_weight_norm,
             ),
             cached=cached,
         )
@@ -223,6 +234,7 @@ class KMISPooling(BasePrecoarseningMixin, SRCPooling):
                 edge_index=adj,
                 so=so,
                 edge_weight=edge_weight,
+                batch_pooled=batch_pooled,
             )
 
             out = PoolingOutput(

--- a/tgp/poolers/lapool.py
+++ b/tgp/poolers/lapool.py
@@ -33,6 +33,9 @@ class LaPooling(BasePrecoarseningMixin, SRCPooling):
             If :obj:`True`, normalize the pooled adjacency matrix by the
             nodes' degree.
             (default: :obj:`True`)
+        edge_weight_norm (bool, optional):
+            Whether to normalize the edge weights by dividing by the maximum absolute value per graph.
+            (default: :obj:`False`)
         lift (~tgp.utils.typing.LiftType, optional):
             Defines how to compute the matrix :math:`\mathbf{S}_\text{inv}` to lift the pooled node features.
 
@@ -76,6 +79,7 @@ class LaPooling(BasePrecoarseningMixin, SRCPooling):
         shortest_path_reg: bool = False,
         remove_self_loops: bool = True,
         degree_norm: bool = True,
+        edge_weight_norm: bool = False,
         lift: LiftType = "precomputed",
         s_inv_op: SinvType = "transpose",
         reduce_red_op: ReduceType = "sum",
@@ -88,7 +92,9 @@ class LaPooling(BasePrecoarseningMixin, SRCPooling):
             reducer=BaseReduce(reduce_op=reduce_red_op),
             lifter=BaseLift(matrix_op=lift, reduce_op=lift_red_op),
             connector=DenseConnectSPT(
-                remove_self_loops=remove_self_loops, degree_norm=degree_norm
+                remove_self_loops=remove_self_loops,
+                degree_norm=degree_norm,
+                edge_weight_norm=edge_weight_norm,
             ),
         )
 
@@ -148,7 +154,10 @@ class LaPooling(BasePrecoarseningMixin, SRCPooling):
 
             # Connect
             edge_index_pooled, edge_weight_pooled = self.connect(
-                edge_index=adj, so=so, edge_weight=edge_weight
+                edge_index=adj,
+                so=so,
+                edge_weight=edge_weight,
+                batch_pooled=batch_pooled,
             )
 
             out = PoolingOutput(

--- a/tgp/poolers/maxcut.py
+++ b/tgp/poolers/maxcut.py
@@ -122,9 +122,7 @@ class MaxCutPooling(SRCPooling):
                 s_inv_op=s_inv_op,
             ),
             reducer=BaseReduce(reduce_op=reduce_red_op),
-            connector=SparseConnect(
-                reduce_op=connect_red_op, normalize_edge_weight=True
-            ),
+            connector=SparseConnect(reduce_op=connect_red_op, edge_weight_norm=True),
             lifter=BaseLift(matrix_op=lift, reduce_op=lift_red_op),
         )
 

--- a/tgp/poolers/maxcut.py
+++ b/tgp/poolers/maxcut.py
@@ -122,7 +122,9 @@ class MaxCutPooling(SRCPooling):
                 s_inv_op=s_inv_op,
             ),
             reducer=BaseReduce(reduce_op=reduce_red_op),
-            connector=SparseConnect(reduce_op=connect_red_op),
+            connector=SparseConnect(
+                reduce_op=connect_red_op, normalize_edge_weight=True
+            ),
             lifter=BaseLift(matrix_op=lift, reduce_op=lift_red_op),
         )
 
@@ -181,7 +183,7 @@ class MaxCutPooling(SRCPooling):
 
         # Connect
         edge_index_pooled, edge_weight_pooled = self.connect(
-            edge_index=adj, so=so, edge_weight=edge_weight
+            edge_index=adj, so=so, edge_weight=edge_weight, batch_pooled=batch_pooled
         )
 
         return PoolingOutput(

--- a/tgp/poolers/maxcut.py
+++ b/tgp/poolers/maxcut.py
@@ -98,7 +98,7 @@ class MaxCutPooling(SRCPooling):
         ratio: Union[float, int] = 0.5,
         assign_all_nodes: bool = True,
         loss_coeff: float = 1.0,
-        mp_units: list = [32, 32, 32, 32, 16, 16, 16, 16, 8, 8, 8, 8],
+        mp_units: list = [32, 32, 32, 32],
         mp_act: str = "tanh",
         mlp_units: list = [16, 16],
         mlp_act: str = "relu",

--- a/tgp/poolers/maxcut.py
+++ b/tgp/poolers/maxcut.py
@@ -88,6 +88,15 @@ class MaxCutPooling(SRCPooling):
             :obj:`~torch_geometric.utils.scatter`,
             e.g., :obj:`'sum'`, :obj:`'mean'`, :obj:`'max'`)
             (default: :obj:`"sum"`)
+        remove_self_loops (bool, optional):
+            If :obj:`True`, the self-loops will be removed from the adjacency matrix.
+            (default: :obj:`True`)
+        degree_norm (bool, optional):
+            If :obj:`True`, the adjacency matrix will be symmetrically normalized.
+            (default: :obj:`False`)
+        edge_weight_norm (bool, optional):
+            Whether to normalize the edge weights by dividing by the maximum absolute value per graph.
+            (default: :obj:`True`)
 
 
     """
@@ -108,6 +117,9 @@ class MaxCutPooling(SRCPooling):
         reduce_red_op: ReduceType = "sum",
         connect_red_op: ConnectionType = "sum",
         lift_red_op: ReduceType = "sum",
+        remove_self_loops: bool = True,
+        degree_norm: bool = False,
+        edge_weight_norm: bool = True,
     ):
         super().__init__(
             selector=MaxCutSelect(
@@ -122,7 +134,12 @@ class MaxCutPooling(SRCPooling):
                 s_inv_op=s_inv_op,
             ),
             reducer=BaseReduce(reduce_op=reduce_red_op),
-            connector=SparseConnect(reduce_op=connect_red_op, edge_weight_norm=True),
+            connector=SparseConnect(
+                reduce_op=connect_red_op,
+                edge_weight_norm=True,
+                degree_norm=degree_norm,
+                remove_self_loops=remove_self_loops,
+            ),
             lifter=BaseLift(matrix_op=lift, reduce_op=lift_red_op),
         )
 

--- a/tgp/poolers/nmf.py
+++ b/tgp/poolers/nmf.py
@@ -47,6 +47,9 @@ class NMFPooling(DenseSRCPooling):
             If :obj:`True`, normalize the pooled adjacency matrix by the
             nodes' degree.
             (default: :obj:`True`)
+        edge_weight_norm (bool, optional):
+            Whether to normalize the edge weights by dividing by the maximum absolute value per graph.
+            (default: :obj:`False`)
         adj_transpose (bool, optional):
             If :obj:`True`, the preprocessing step in :class:`~tgp.src.DenseSRCPooling` and
             the :class:`~tgp.connect.DenseConnect` operation returns transposed
@@ -79,6 +82,7 @@ class NMFPooling(DenseSRCPooling):
         cached: bool = False,
         remove_self_loops: bool = True,
         degree_norm: bool = True,
+        edge_weight_norm: bool = False,
         adj_transpose: bool = True,
         lift: LiftType = "precomputed",
         s_inv_op: SinvType = "transpose",
@@ -91,6 +95,7 @@ class NMFPooling(DenseSRCPooling):
                 remove_self_loops=remove_self_loops,
                 degree_norm=degree_norm,
                 adj_transpose=adj_transpose,
+                edge_weight_norm=edge_weight_norm,
             ),
             cached=cached,
             adj_transpose=adj_transpose,
@@ -102,6 +107,7 @@ class NMFPooling(DenseSRCPooling):
         self.preconnector = DenseConnectSPT(
             remove_self_loops=remove_self_loops,
             degree_norm=degree_norm,
+            edge_weight_norm=edge_weight_norm,
         )
 
     def forward(

--- a/tgp/poolers/pan.py
+++ b/tgp/poolers/pan.py
@@ -89,6 +89,15 @@ class PANPooling(SRCPooling):
             Can be any string of class :class:`~tgp.utils.typing.ReduceType` admitted by
             :obj:`~torch_geometric.utils.scatter`,
             e.g., :obj:`'sum'`, :obj:`'mean'`, :obj:`'max'`) (default: :obj:`"sum"`)
+        remove_self_loops (bool, optional):
+            If :obj:`True`, the self-loops will be removed from the adjacency matrix.
+            (default: :obj:`False`)
+        degree_norm (bool, optional):
+            If :obj:`True`, the adjacency matrix will be symmetrically normalized.
+            (default: :obj:`False`)
+        edge_weight_norm (bool, optional):
+            Whether to normalize the edge weights by dividing by the maximum absolute value per graph.
+            (default: :obj:`False`)
     """
 
     def __init__(
@@ -103,6 +112,9 @@ class PANPooling(SRCPooling):
         reduce_red_op: ReduceType = "sum",
         connect_red_op: ReduceType = "sum",
         lift_red_op: ReduceType = "sum",
+        remove_self_loops: bool = False,
+        degree_norm: bool = False,
+        edge_weight_norm: bool = False,
     ):
         super().__init__(
             selector=TopkSelect(
@@ -110,7 +122,12 @@ class PANPooling(SRCPooling):
             ),
             reducer=BaseReduce(reduce_op=reduce_red_op),
             lifter=BaseLift(matrix_op=lift, reduce_op=lift_red_op),
-            connector=SparseConnect(remove_self_loops=False, reduce_op=connect_red_op),
+            connector=SparseConnect(
+                remove_self_loops=remove_self_loops,
+                reduce_op=connect_red_op,
+                degree_norm=degree_norm,
+                edge_weight_norm=edge_weight_norm,
+            ),
         )
 
         self.in_channels = in_channels
@@ -184,7 +201,7 @@ class PANPooling(SRCPooling):
             x = self.multiplier * x if self.multiplier != 1 else x
 
             # Connect
-            adj_pool, _ = self.connect(edge_index=adj, so=so)
+            adj_pool, _ = self.connect(edge_index=adj, so=so, batch_pooled=batch_pooled)
 
             out = PoolingOutput(
                 x=x, edge_index=adj_pool, edge_weight=None, batch=batch_pooled, so=so

--- a/tgp/poolers/sag.py
+++ b/tgp/poolers/sag.py
@@ -92,6 +92,15 @@ class SAGPooling(SRCPooling):
             :obj:`~torch_geometric.utils.scatter`,
             e.g., :obj:`'sum'`, :obj:`'mean'`, :obj:`'max'`)
             (default: :obj:`"sum"`)
+        remove_self_loops (bool, optional):
+            If :obj:`True`, the self-loops will be removed from the adjacency matrix.
+            (default: :obj:`True`)
+        degree_norm (bool, optional):
+            If :obj:`True`, the adjacency matrix will be symmetrically normalized.
+            (default: :obj:`False`)
+        edge_weight_norm (bool, optional):
+            Whether to normalize the edge weights by dividing by the maximum absolute value per graph.
+            (default: :obj:`False`)
         **kwargs (any, optional):
             Additional parameters for initializing the graph
             neural network layer.
@@ -110,6 +119,9 @@ class SAGPooling(SRCPooling):
         reduce_red_op: ReduceType = "sum",
         connect_red_op: ReduceType = "sum",
         lift_red_op: ReduceType = "sum",
+        remove_self_loops: bool = True,
+        degree_norm: bool = False,
+        edge_weight_norm: bool = False,
         **kwargs,
     ):
         super().__init__(
@@ -118,7 +130,12 @@ class SAGPooling(SRCPooling):
             ),
             reducer=BaseReduce(reduce_op=reduce_red_op),
             lifter=BaseLift(matrix_op=lift, reduce_op=lift_red_op),
-            connector=SparseConnect(reduce_op=connect_red_op),
+            connector=SparseConnect(
+                reduce_op=connect_red_op,
+                degree_norm=degree_norm,
+                edge_weight_norm=edge_weight_norm,
+                remove_self_loops=remove_self_loops,
+            ),
         )
 
         # keep only the kwargs that are used in the GNN
@@ -193,7 +210,10 @@ class SAGPooling(SRCPooling):
 
             # Connect
             edge_index_pooled, edge_weight_pooled = self.connect(
-                edge_index=adj, so=so, edge_weight=edge_weight
+                edge_index=adj,
+                so=so,
+                edge_weight=edge_weight,
+                batch_pooled=batch_pooled,
             )
 
             out = PoolingOutput(

--- a/tgp/select/maxcut_select.py
+++ b/tgp/select/maxcut_select.py
@@ -47,6 +47,8 @@ class MaxCutScoreNet(torch.nn.Module):
     ):
         super().__init__()
 
+        self.initial_layer = Linear(in_channels, in_channels)  # initial embedding
+
         # Message passing layers
         if mp_act.lower() in ["identity", "none"]:
             self.mp_act = lambda x: x
@@ -104,6 +106,8 @@ class MaxCutScoreNet(torch.nn.Module):
         edge_index, edge_weight = delta_gcn_matrix(
             edge_index, edge_weight, delta=self.delta
         )
+
+        x = self.initial_layer(x)  # initial embedding
 
         # Message passing layers
         for mp_conv in self.mp_convs:


### PR DESCRIPTION
Now almost all poolers have:
- degree_norm : possibility to normalize the pooled adj using degree
- edge_weight_norm: possibility to normalize the pooled adj using the norm of the weights
- remove_self_loops: possibility to remove self loops from the pooled adj

Some other minor fixes to min/maxcut losses and examples scripts.

