### PR TITLE
precoarsenable property + kmis

### DIFF
--- a/tgp/data/transforms.py
+++ b/tgp/data/transforms.py
@@ -202,7 +202,7 @@ class PreCoarsening(BaseTransform):
     ) -> None:
         super().__init__()
         assert isinstance(pooler, SRCPooling)
-        assert not pooler.is_trainable, "The pooler must not be trainable."
+        assert pooler.is_precoarsenable, "The pooler must be precoarsenable."
         self.pooler = pooler
         self.input_key = input_key
         self.output_key = output_key
@@ -217,7 +217,6 @@ class PreCoarsening(BaseTransform):
         pooled_out = []
         for d in range(self.recursive_depth):
             data_pooled = self.pooler.precoarsening(
-                x=data_obj.x,
                 edge_index=data_obj.edge_index,
                 edge_weight=data_obj.edge_weight,
                 batch=data_obj.batch,


### PR DESCRIPTION
Added is_precoarsenable as SRC property. The idea is to check whether the select forward is fed with the x or not (and the pooler is non trainable).

modified KMISSelect's forward signature to be dynamic depending on the scorer.
